### PR TITLE
Novo modelo de CFP

### DIFF
--- a/.github/ISSUE_TEMPLATE/palestrante_template.md
+++ b/.github/ISSUE_TEMPLATE/palestrante_template.md
@@ -1,0 +1,18 @@
+Nome: **Nome Completo**
+E-mail: usuario@empresa.com
+Cidade: *Rio de Janeiro - RJ*
+Site e blog: link para o site ou blog (opcional)
+Facebook: [usuario](https://www.facebook.com/usuario) (opcional)
+Twitter: [usuario](https://twitter.com/usuario) (opcional)
+GitHub: [usuario](https://github.com/usuario) (opcional)
+LinkedIn: [usuario](https://www.linkedin.com/in/usuario) (opcional)
+SpeakerDeck e SlideShare: [usuario](https://speakerdeck.com/usuario) (opcional)
+Imagem: link para a foto do palestrante
+Biografia:
+
+>  Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,15 @@
+Título: **Título descritivo e interessante**
+Palavras-chaves: `keyword1`, `keyword2`, `keyword3`
+Nível: **básico**
+Palestrante: [**Nome Completo**](número da issue com dados do palestrante)
+Descrição da palestra:
+> Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
+tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non
+proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+
+Slides: link para os slides publicado (opcional)
+Vídeo: link para o vídeo publicado (opcional)
+GitHub: link para repositório do GitHub com exemplos (opcional)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 
 ---
 
-# Call for Papers para meetups do PHPRio
+# Call for Papers para Meetups do PHPRio
 
 A ideia deste repositório é permitir que palestrantes cadastrem suas **propostas de palestras** para serem apresentadas nos Meetups do grupo PHPRio, onde as pessoas interessadas poderão interagir e votar em suas preferidas.
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,76 @@
+<h1 align="center">Quero Palestrar!</h1>
+<p align="center">
+    Repositório de <i>palestrantes</i> e <i>propostas de palestras</i> para eventos de tecnologia.
+</p>
+<p align="center">
+    <a href="issues/new?template=palestrante_template.md">
+        <img src="https://user-images.githubusercontent.com/753958/31695073-e7acfc00-b386-11e7-9fa0-26a133d56eaa.png" alt="Cadastrar Palestrante" width="177" />
+    </a>
+    <a href="issues/new">
+        <img src="https://user-images.githubusercontent.com/753958/31695094-19f445c4-b387-11e7-871a-0a08170911bf.png" alt="Cadastrar Palestra" width="160" />
+    </a>
+</p>
+
+---
+<h2 align="center">Temas</h2>
+<p align="center">
+    <a href="#">
+        Palestrantes
+    </a>&nbsp;
+    <a href="#">
+        Palestras
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/arquitetura">
+        Arquitetura
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/boas%20pr%C3%A1ticas">
+        Boas práticas
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/Carreira">
+        Carreira
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/Infraestrutura">
+        Intraestrutura
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/POO">
+        POO
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/Seguran%C3%A7a">
+        Segurança
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/testes">
+        Testes
+    </a>&nbsp;
+</p>
+<h2 align="center">Níveis</h2>
+<p align="center">
+    <a href="https://github.com/PHPRio/CFP/labels/iniciante">
+        Iniciante
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/intermadi%C3%A1rio">
+        Intermediário
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/avan%C3%A7ado">
+        Avançado
+    </a>&nbsp;
+</p>
+
+---
+
 # Call for Papers para meetups do PHPRio
 
-Repositório para sugestões de palestras, workshops e outras atividades da comunidade PHPRio.
+A ideia deste repositório é permitir que palestrantes cadastrem suas **propostas de palestras** para serem apresentadas nos Meetups do grupo PHPRio, onde as pessoas interessadas poderão interagir e votar em suas preferidas.
+
+## Como funciona?
+
+Para que uma proposta seja criada, antes deve-se cadastrar o palestrante. Para isso, simplesmente clique em [Cadastrar Palestrante](#).
+
+Após realizar este cadastro seguindo o template sugerido na área de inserção, a proposta da palestra poderá ser feita clicando em [Cadastrar Palestra](#)
 
 As propostas encontram-se nas [issues](https://github.com/PHPRio/cpf/issues/) do repositório. Utilize labels para o nível da palestra (iniciante, intermediário, avançado) e assunto (arquitetura, POO, testes, etc)
 
-## Quero palestrar
-* Abra uma [issue](https://github.com/PHPRio/cpf/issues/new) com o título e descrição da palestra
+## Como participar sem ser palestrante
 
-## Quero sugerir uma palestra
-* Abra uma [issue](https://github.com/PHPRio/cpf/issues/new) com o título sugerido e na descrição cite qual conteúdo acha mais interessante
+Conforme mencionado anteriormente, é de grande valor a interação de todos os interessados nos eventos. Com isso, podemos selecionar melhores e mais relevantes conteúdos.
 
-## Quero contribuir mas não sei como
-* Vote e comente nas propostas, qualquer feedback é importante
+Não deixe de votar nas propostas que te agradam, e comente caso tenha sugestões também. Todo feedback é bem vindo!

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
     Repositório de <i>palestrantes</i> e <i>propostas de palestras</i> para eventos de tecnologia.
 </p>
 <p align="center">
-    <a href="issues/new?template=palestrante_template.md">
+    <a href="https://github.com/PHPRio/cpf/issues/new?template=palestrante_template.md">
         <img src="https://user-images.githubusercontent.com/753958/31695073-e7acfc00-b386-11e7-9fa0-26a133d56eaa.png" alt="Cadastrar Palestrante" width="177" />
     </a>
-    <a href="issues/new">
+    <a href="https://github.com/PHPRio/cpf/issues/new">
         <img src="https://user-images.githubusercontent.com/753958/31695094-19f445c4-b387-11e7-871a-0a08170911bf.png" alt="Cadastrar Palestra" width="160" />
     </a>
 </p>

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 ---
 <h2 align="center">Consulte</h2>
 <p align="center">
-    <a href="#">
+    <a href="https://github.com/PHPRio/cpf/issues?q=is%3Aissue+is%3Aopen+label%3APalestrantes">
         Palestrantes
     </a>&nbsp;
-    <a href="#">
+    <a href="https://github.com/PHPRio/cpf/issues?q=is%3Aissue+is%3Aopen+label%3APalestras">
         Palestras
     </a>&nbsp;
 </p>

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 <h1 align="center">Quero Palestrar!</h1>
 <p align="center">
-    Repositório de <i>palestrantes</i> e <i>propostas de palestras</i> para eventos de tecnologia.
+    Repositório de <i>palestrantes</i> e <i>propostas de palestras</i> para Meetups do PHPRio
 </p>
 <p align="center">
-    <a href="https://github.com/PHPRio/cpf/issues/new?template=palestrante_template.md">
-        <img src="https://user-images.githubusercontent.com/753958/31695073-e7acfc00-b386-11e7-9fa0-26a133d56eaa.png" alt="Cadastrar Palestrante" width="177" />
-    </a>
-    <a href="https://github.com/PHPRio/cpf/issues/new">
-        <img src="https://user-images.githubusercontent.com/753958/31695094-19f445c4-b387-11e7-871a-0a08170911bf.png" alt="Cadastrar Palestra" width="160" />
-    </a>
+    <a href="https://github.com/PHPRio/cpf/issues/new?template=palestrante_template.md"><img src="https://user-images.githubusercontent.com/753958/31695073-e7acfc00-b386-11e7-9fa0-26a133d56eaa.png" alt="Cadastrar Palestrante" width="177" /></a>&nbsp;
+    <a href="https://github.com/PHPRio/cpf/issues/new"><img src="https://user-images.githubusercontent.com/753958/31695094-19f445c4-b387-11e7-871a-0a08170911bf.png" alt="Cadastrar Palestra" width="160" /></a>
 </p>
 
 ---
-<h2 align="center">Temas</h2>
+<h2 align="center">Consulte</h2>
 <p align="center">
     <a href="#">
         Palestrantes
@@ -20,6 +16,23 @@
     <a href="#">
         Palestras
     </a>&nbsp;
+</p>
+
+<h2 align="center">Níveis</h2>
+<p align="center">
+    <a href="https://github.com/PHPRio/CFP/labels/iniciante">
+        Iniciante
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/intermadi%C3%A1rio">
+        Intermediário
+    </a>&nbsp;
+    <a href="https://github.com/PHPRio/CFP/labels/avan%C3%A7ado">
+        Avançado
+    </a>&nbsp;
+</p>
+
+<h2 align="center">Temas</h2>
+<p align="center">
     <a href="https://github.com/PHPRio/CFP/labels/arquitetura">
         Arquitetura
     </a>&nbsp;
@@ -40,18 +53,6 @@
     </a>&nbsp;
     <a href="https://github.com/PHPRio/CFP/labels/testes">
         Testes
-    </a>&nbsp;
-</p>
-<h2 align="center">Níveis</h2>
-<p align="center">
-    <a href="https://github.com/PHPRio/CFP/labels/iniciante">
-        Iniciante
-    </a>&nbsp;
-    <a href="https://github.com/PHPRio/CFP/labels/intermadi%C3%A1rio">
-        Intermediário
-    </a>&nbsp;
-    <a href="https://github.com/PHPRio/CFP/labels/avan%C3%A7ado">
-        Avançado
     </a>&nbsp;
 </p>
 


### PR DESCRIPTION
Novo modelo para abertura de propostas de palestras feito com base no do PHPSP. Agora também existiria um cadastro de palestrante, que seria vinculado com o cadastro da palestra.

Para manter a organização, seria interessante adicionar a label _Palestras_ a todas as palestras já cadastradas.